### PR TITLE
Added CheckARPcore.py and CheckSubnet.py

### DIFF
--- a/CheckARPcore.py
+++ b/CheckARPcore.py
@@ -2,6 +2,7 @@
 from netmiko import ConnectHandler
 from datetime import datetime
 import csv, os.path
+from netaddr import IPNetwork
 #Local imports
 import credentials
 
@@ -9,7 +10,7 @@ import credentials
 start_time = datetime.now()
 
 # Define the primary function (to be moved to a separate module some day...)
-def nc(username, password, secret, customer):
+def nc(username, password, secret, customer, subnet, ticketnum):
     with open(customer, mode='r') as csvfile:
         reader = csv.DictReader(csvfile)
         # Now iterate through every row in the CSVfile and make dictionaries
@@ -28,25 +29,34 @@ def nc(username, password, secret, customer):
             # This is your connection handler for commands from here on out
             net_connect = ConnectHandler(**switch)
             # Insert your commands here
-            # net_connect.enable()
-            # or maybe send configuration stuff with
-            # net_connect.send_config_set(username cisco priv 15 pass cisco)
-            connect_return = net_connect.send_command(command_string)
+            net_connect.enable()
+            # Send log for beginning
+            net_connect.send_command('send log "Beginning ARP check ticket {}"'.format(ticketnum))
             # Now make it pretty
             print "\n\n>>>>>>>>> Device {0} <<<<<<<<<".format(row['SysName'])
-            print connect_return
+            for ip in IPNetwork(subnet):
+                sh_arp = net_connect.send_command("show arp | include %s" % ip)
+                if sh_arp != "":
+                    print "%s found" % ip
+                else:
+                    pass
             print "\n>>>>>>>>> End <<<<<<<<<"
+            # Finish logging
+            net_connect.send_command('send log "Completing ARP check ticket {}"'.format(ticketnum))
             # Disconnect from this session
             net_connect.disconnect()
 
 # Grab the Customer name to search
 customer = raw_input('Customer name: ') + ".csv"
+# Grab the subnet to check for
+subnet = raw_input('Subnet to check for in slash notation: ')
 # Flesh out these variables using the credentials.cred_csv module
 username, password, secret = credentials.cred_csv()
-# Give it a command:
+# Enter ticket number for SW change logging
+ticketnum = raw_input('Ticket #: ')
 # command_string = "write mem" # can be passed to nc...
 # Run the primary function in this program
-nc(username, password, secret, customer)
+nc(username, password, secret, customer, subnet, ticketnum)
 
 
 end_time = datetime.now()

--- a/CheckSubnet.py
+++ b/CheckSubnet.py
@@ -1,0 +1,7 @@
+from netaddr import IPNetwork
+
+# Ask for the CIDR
+Cidr_check = raw_input("What is the range you want to view? ")
+
+for ip in IPNetwork(Cidr_check):
+    print '%s' % ip


### PR DESCRIPTION
This adds two scripts:

## CheckSubnet.py
This is simple: plop in a slash notation CIDR address and it spits out every IP in that range. Handy for checking yourself

## CheckARPcore.py
Also simple: Asks for the **customer** (a converted-from-SW CSV with all four pairs of core routers + GW routers I call DCL3), **CIDR address** that needs to be verified is not in use, and **Ticket number** for sending log entries to the device. 
It returns a section for each device scanned and make it easy to see where specific IP's are ARPing from. I may tweak it to return the whole ARP line.
It's an extrapolated use of "sh arp | in %s" % CIDR_address